### PR TITLE
iss#257/LEPP_PPN2E_DEP - closes iss#257

### DIFF
--- a/final/EU/LEBB/LEBB_v0.1.txt
+++ b/final/EU/LEBB/LEBB_v0.1.txt
@@ -1215,7 +1215,6 @@ route5 = MAP3A, Mapax tree alpha
  	N43.68375, W3.04408
 
 route6 = PPN2E, Pamplona two echo
-	N43.29667, W2.89917,
  	N43.32389, W2.97306,
  	N43.32389, W2.97306,
  	N43.32479, W2.97499,


### PR DESCRIPTION
### Issue description
Aircraft departing on the PPN2E SID make a right-hand 360º turn before joining the departure, therefore climbing and interfering with other traffic

### Issue solution
Deleted a point in the rwy30 threshold that aircraft were looking for on departure