### PR TITLE
iss#259/LEBB_SSN2A_DEP - closes issue

### DIFF
--- a/final/EU/LEBB/LEBB_v0.1.txt
+++ b/final/EU/LEBB/LEBB_v0.1.txt
@@ -1252,7 +1252,6 @@ route6 = PPN2E, Pamplona two echo
  	N42.73375, W1.702
 
 route7 = SSN2A, San sebastian two alpha
-	N43.29667, W2.89917,
  	N43.32389, W2.97306,
  	N43.32389, W2.97306,
  	N43.32479, W2.97499,


### PR DESCRIPTION
### Issue description
Aircraft departing on the SSN2A SID make a right-hand 360º turn before joining the departure, therefore climbing and interfering with other traffic

### Issue solution
Deleted a point in the rwy30 threshold that aircraft were looking for on departure